### PR TITLE
feat: add support for line break on text value component

### DIFF
--- a/projects/ngx-contentful-rich-text/src/lib/components/text-value.component.ts
+++ b/projects/ngx-contentful-rich-text/src/lib/components/text-value.component.ts
@@ -1,10 +1,36 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnInit,
+  RendererFactory2,
+  ViewContainerRef,
+} from '@angular/core';
 import { Text } from '@contentful/rich-text-types';
 
 @Component({
-  template: '{{ node.value }}',
+  template: '',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TextValueComponent {
+export class TextValueComponent implements OnInit {
   @Input() node: Text;
+
+  constructor(
+    private viewContainer: ViewContainerRef,
+    private rendererFactory: RendererFactory2
+  ) {}
+
+  ngOnInit(): void {
+    if (this.node && this.node.value) {
+      const textBlocks = this.node.value.split('\n');
+      const host = this.viewContainer.element.nativeElement;
+      const renderer = this.rendererFactory.createRenderer(host, null);
+      textBlocks.forEach((block, index) => {
+        renderer.appendChild(host, renderer.createText(block));
+        if (textBlocks.length > index + 1) {
+          renderer.appendChild(host, renderer.createElement('br'));
+        }
+      });
+    }
+  }
 }

--- a/projects/ngx-contentful-rich-text/src/lib/ngx-contentful-rich-text.component.spec.ts
+++ b/projects/ngx-contentful-rich-text/src/lib/ngx-contentful-rich-text.component.spec.ts
@@ -5,7 +5,6 @@ import {
   TestModuleMetadata,
   async,
 } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import {
   BLOCKS,
   Block,


### PR DESCRIPTION
This PR fix #4 
It adds support for line break on `TextValueComponent`. 

Tested locally on project that implements this library and modified unit tests to cater for change and check existence of LineBreaks on all block types.