### PR TITLE
Add CSS classes to ngx-contentful-richtext component and to renderers

### DIFF
--- a/projects/ngx-contentful-rich-text/src/lib/components/default-mark-renderer.component.ts
+++ b/projects/ngx-contentful-rich-text/src/lib/components/default-mark-renderer.component.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding } from '@angular/core';
 import { MARKS } from '@contentful/rich-text-types';
-
 import { MarkRenderer } from '../classes/mark-renderer.class';
 
 export const TEXT = `<ng-container ngxMarkRendererHost [node]="node"></ng-container>`;
@@ -17,5 +16,7 @@ export const TEXT = `<ng-container ngxMarkRendererHost [node]="node"></ng-contai
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DefaultMarkRendererComponent extends MarkRenderer {
+  @HostBinding('class') class = 'default-mark-renderer';
+
   MARKS: typeof MARKS = MARKS;
 }

--- a/projects/ngx-contentful-rich-text/src/lib/components/default-node-renderer.component.ts
+++ b/projects/ngx-contentful-rich-text/src/lib/components/default-node-renderer.component.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding } from '@angular/core';
 import { BLOCKS, INLINES } from '@contentful/rich-text-types';
-
 import { NodeRenderer } from '../classes/node-renderer.class';
 
 export const CHILDREN =
@@ -47,6 +46,8 @@ const DEFAULT_INLINE =
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DefaultNodeRendererComponent extends NodeRenderer {
+  @HostBinding('class') class = 'default-node-renderer';
+
   BLOCKS: typeof BLOCKS = BLOCKS;
   INLINES: typeof INLINES = INLINES;
 }

--- a/projects/ngx-contentful-rich-text/src/lib/components/text-value.component.ts
+++ b/projects/ngx-contentful-rich-text/src/lib/components/text-value.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  Input,
+} from '@angular/core';
 import { Text } from '@contentful/rich-text-types';
 
 @Component({
@@ -6,5 +11,7 @@ import { Text } from '@contentful/rich-text-types';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextValueComponent {
+  @HostBinding('class') class = 'text-value';
+
   @Input() node: Text;
 }

--- a/projects/ngx-contentful-rich-text/src/lib/ngx-contentful-rich-text.component.ts
+++ b/projects/ngx-contentful-rich-text/src/lib/ngx-contentful-rich-text.component.ts
@@ -1,13 +1,13 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  HostBinding,
   Input,
   OnChanges,
   OnInit,
   SimpleChanges,
 } from '@angular/core';
 import { Block, Document, Inline } from '@contentful/rich-text-types';
-
 import {
   MarkRendererResolver,
   NodeRendererResolver,
@@ -34,6 +34,8 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NgxContentfulRichTextComponent implements OnInit, OnChanges {
+  @HostBinding('class') class = 'ngx-contentful-rich-text';
+
   /** Document to render */
   @Input() document: Document;
 


### PR DESCRIPTION
Fixes #8

It adds a class name to `NgxContentfulRichTextComponent` `DefaultMarkRendererComponent` `TextValueComponent` and `DefaultNodeRendererComponent`.

I needed these class name for my project in order to add some custom CSS rules.

The class names may not be good, I can change this if needed.

Thank you =)